### PR TITLE
Initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+cov_profile/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,238 @@
-# 🚧 WORK IN PROGRESS. See [#1](https://github.com/octokit/auth-oauth-user-client.js/pull/1) | [Preview](https://github.com/octokit/auth-oauth-user-client.js/tree/initial-version#readme)
-
 # auth-oauth-user-client.js
 
-> OAuth user authentication without exposing client secret
+Authentication strategy for Octokit without exposing client secret.
+
+## Backend service
+
+`auth-oauth-user-client.js` requires a backend service to function.
+[`@octokit/oauth-app`](https://github.com/octokit/oauth-app.js) provides the
+compatible Node.js/Express.js/Cloudflare Worker/Deno middlewares to interact
+with `auth-oauth-user-client.js`.
+
+## Browsers
+
+Load directly from CDNs:
+
+- jsdelivr:
+  `https://cdn.jsdelivr.net/gh/octokit/auth-oauth-user-client.js@v0.1.0/dist/index.min.js`
+
+```html
+<script type="module">
+  import { createOAuthUserClientAuth } from "https://cdn.jsdelivr.net/gh/octokit/auth-oauth-user-client.js@v0.1.0/dist/index.min.js";
+</script>
+```
+
+## Create An Authenticator Instance
+
+```js
+const authenticator = createOAuthUserClientAuth({
+  clientId: "client_id", // get client id from https://github.com/settings/apps
+  clientType: "github-app", // "github-app" | "oauth-app"
+  expirationEnabled: true, // true | false
+});
+```
+
+## Get Token
+
+Use `{ type: "getToken" }` method to get authentication object from
+[`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
+Returns `null` when there is no authentication object found in `localStorage`.
+
+When both `code` and `state` search parameters are present (user being
+redirected from GitHub login url), `"getToken"` method will automatically
+exchange the `code` search parameter for an authentication object using the
+[backend service](#backend-service).
+
+```js
+const auth = await authenticator(); // ≡ ({ type: "getToken" })
+```
+
+## Sign In
+
+Use `signIn` method to clear authentication object from `localStorage` and
+redirect user to GitHub login url.
+
+```js
+if (!auth) await authenticator({ type: "signIn" });
+```
+
+## All Methods
+
+| `{ type: ? }`           | Meaning                                           | Note                                                                                                                                                                                            |
+| :---------------------- | :------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"getToken"`            | Get token                                         | See [Get token](#get-token).                                                                                                                                                                    |
+| `"signIn"`              | [Sign in][m1]                                     | See [Sign in](#sign-in).                                                                                                                                                                        |
+| `"createToken"`         | [Exchange `code` in url parameters for token][m2] | Normally the `getToken` method will exchange `code` for an access token automatically when both `code` and `state` search parameters are present (user being redirected from GitHub login url). |
+| `"checkToken"`          | [Check a token][m3]                               | —                                                                                                                                                                                               |
+| `"createScopedToken"`   | [Create a scoped access token][m4]                | For OAuth app only. Specify extra parameters like `{ type: "createScopedToken", target: ... }`.                                                                                                 |
+| `"resetToken"`          | [Reset a token][m5]                               | —                                                                                                                                                                                               |
+| `"renewToken"`          | [Renewing a user token with a refresh token][m6]  | The app should enable token expiration in settings (GitHub App only currently)                                                                                                                  |
+| `"deleteToken"`         | [Delete an app token][m7]                         | Use `{ type = "deleteToken", offline: true }` to delete authentication from `localStorage` without calling GitHub API via backend service.                                                      |
+| `"deleteAuthorization"` | [Delete an app authorization][m8]                 |                                                                                                                                                                                                 |
+
+[m1]: https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity
+[m2]: https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
+[m3]: https://docs.github.com/en/rest/reference/apps#check-a-token
+[m4]: https://docs.github.com/en/rest/reference/apps#create-a-scoped-access-token
+[m5]: https://docs.github.com/en/rest/reference/apps#reset-a-token
+[m6]: https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens#renewing-a-user-token-with-a-refresh-token
+[m7]: https://docs.github.com/en/rest/reference/apps#delete-an-app-token
+[m8]: https://docs.github.com/en/rest/reference/apps#delete-an-app-authorization
+
+## Usage with Octokit
+
+To use `@octokit/auth-oauth-user-client` with
+[`@octokit/core`](https://github.com/octokit/core.js)-compatible
+modules, specify the authentication strategy and authentication strategy
+options.
+
+```html
+<script type="module">
+  import { Octokit } from "https://cdn.skypack.dev/@octokit/octokit";
+  import { createOAuthUserClientAuth } from "https://cdn.jsdelivr.net/gh/octokit/auth-oauth-user-client.js@v0.1.0/dist/index.min.js";
+
+  const octokit = new Octokit({
+    authStrategy: createOAuthUserClientAuth,
+    auth: {
+      clientId: "client_id", // get client id from https://github.com/settings/apps
+      clientType: "github-app", // "github-app" | "oauth-app"
+      expirationEnabled: true, // true | false
+    },
+  });
+
+  const auth = await octokit.auth();
+  if (!auth) await octokit.auth({ type: "signIn" });
+  else console.log(await octokit.rest.users.getAuthenticated());
+</script>
+```
+
+Or
+
+```html
+<script type="module">
+  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
+  import { createOAuthUserClientAuth } from "https://cdn.jsdelivr.net/gh/octokit/auth-oauth-user-client.js@v0.1.0/dist/index.min.js";
+
+  const octokit = new Octokit({
+    authStrategy: createOAuthUserClientAuth,
+    auth: {
+      clientId: "client_id", // get client id from https://github.com/settings/apps
+      clientType: "github-app", // "github-app" | "oauth-app"
+      expirationEnabled: true, // true | false
+    },
+  });
+
+  const auth = await octokit.auth();
+  if (!auth) await octokit.auth({ type: "signIn" });
+  else console.log(await octokit.request("GET /user"));
+</script>
+```
+
+## `createOAuthUserClientAuth(options)` or `new Octokit({auth})`
+
+The `createOAuthUserClientAuth` method accepts a single `options` object as argument:
+
+| name                    | type                | description                                                                                                                                                                                             |
+| :---------------------- | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`clientId`**          | `string`            | **`Required`**. Find **Client ID** on the app’s about page in settings.                                                                                                                                 |
+| **`clientType`**        | `string`            | **`Required`**. Either `"oauth-app"` or `"github-app"`.                                                                                                                                                 |
+| **`expirationEnabled`** | `boolean`           | **`Required`**. `true` or `false` for GitHub App. `false` for OAuth App. Set according to app settings.                                                                                                 |
+| **`auth`**              | `object`            | Initial authentication object, defaults to `null`. See [authentication object](#authentication-object).                                                                                                 |
+| **`defaultScopes`**     | `string`            | Only relevant for OAuth App. See [available scopes](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes).                                                                 |
+| **`serviceOrigin`**     | `string`            | Defaults to `location.origin`. Required only when the `@octokit/oauth-app` Node.js/Express.js/Cloudflare middleware is deployed at a different origin.                                                  |
+| **`servicePathPrefix`** | `string`            | Defaults to `"/api/github/oauth"`. Required only when the `@octokit/oauth-app` Node.js/Express.js/Cloudflare middleware is created with custom `pathPrefix`.                                            |
+| **`authStore`**         | `object` or `false` | Custom store to get/set [authentication object](#authentication-object), `false` to disable persistence of authentication object. See [custom store](#custom-store).                                    |
+| **`stateStore`**        | `object` or `false` | Custom store to get/set [state string](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#parameters), `false` to disable persistence of state string.               |
+| **`request`**           | `function`          | You can pass in your own [`@octokit/request`](https://github.com/octokit/request.js) instance. For usage with enterprise, set `baseUrl` to the API root endpoint. See [custom request](#custom-request) |
+
+### Custom Store
+
+By default, `auth-oauth-user-client.js` uses [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) to store JSON
+serialized authentication object and `state` string.
+
+Pass `authStore` or `stateStore` in `createOAuthUserClientAuth(options)` (or
+`new Octokit({auth})`) to use your custom code to persist authentication object
+or `state` string.
+
+For example:
+
+```js
+const authStore = {
+  get: async() => {
+  // return persisted authentication object when user is signed in;
+  // returns `null` when user is signed out
+  }
+  set: async(auth) => {
+    if (auth == null) { /* delete persisted authentication object */ }
+    else { /* create or update persisted authentication object */ }
+  }
+}
+
+const auth = createOAuthUserClientAuth({
+  clientId: "client_id",
+  authStore
+});
+```
+
+## Authentication Object
+
+The async `auth(options)` method returns to an authentication object. There are
+three possible types of authentication object:
+
+1. [OAuth APP authentication token](#oauth-app-authentication-token)
+2. [GitHub APP user authentication token with expiring disabled](#github-app-user-authentication-token-with-expiring-disabled)
+3. [GitHub APP user authentication token with expiring enabled](#github-app-user-authentication-token-with-expiring-enabled)
+
+The differences are
+
+1. `scopes` is only present for OAuth Apps
+2. `refreshToken`, `expiresAt`, `refreshTokenExpiresAt` are only present for GitHub Apps, and only if token expiration is enabled
+
+### OAuth APP Authentication Object
+
+| name             | type               | description                                |
+| :--------------- | :----------------- | :----------------------------------------- |
+| **`type`**       | `string`           | `"token"`                                  |
+| **`tokenType`**  | `string`           | `"oauth"`                                  |
+| **`clientType`** | `string`           | `"oauth-app"`                              |
+| **`clientId`**   | `string`           | Client id of the app                       |
+| **`token`**      | `string`           | The user access token                      |
+| **`scopes`**     | `array of strings` | Array of scope names enabled for the token |
+
+### GitHub APP Authentication Object (Expiring Disabled)
+
+| name             | type     | description           |
+| :--------------- | :------- | :-------------------- |
+| **`type`**       | `string` | `"token"`             |
+| **`tokenType`**  | `string` | `"oauth"`             |
+| **`clientType`** | `string` | `"github-app"`        |
+| **`clientId`**   | `string` | Client id of the app  |
+| **`token`**      | `string` | The user access token |
+
+### GitHub APP Authentication Object (Expiring Enabled)
+
+| name                        | type     | description                                                     |
+| :-------------------------- | :------- | :-------------------------------------------------------------- |
+| **`type`**                  | `string` | `"token"`                                                       |
+| **`tokenType`**             | `string` | `"oauth"`                                                       |
+| **`clientType`**            | `string` | `"github-app"`                                                  |
+| **`clientId`**              | `string` | Client id of the app                                            |
+| **`token`**                 | `string` | The user access token                                           |
+| **`refreshToken`**          | `string` | The refresh token                                               |
+| **`expiresAt`**             | `string` | Date in [ISO 8601][iso] format, e.g: `2011-10-05T14:48:00.000Z` |
+| **`refreshTokenExpiresAt`** | `string` | Date in [ISO 8601][iso] format, e.g: `2011-10-05T14:48:00.000Z` |
+
+[iso]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+
+## Development
+
+Although targeting browsers, this module is written, tested, and bundled using
+[Deno](https://deno.land) for its simplicity.
+
+- test: `deno test --location=https://acme.com/search?q=octokit --coverage=cov_profile`
+- show coverage: `deno coverage cov_profile`
+- bundle: `deno bundle src/index.ts dist/index.bundle.js`
+- minify: `esbuild dist/index.bundle.js --minify --outfile=dist/index.min.js`
 
 ## Contributing
 

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,7 @@
+{
+  "importMap": "./import_map.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "lib": ["deno.ns", "dom"]
+  }
+}

--- a/import_map.json
+++ b/import_map.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "/": "./",
+    "./": "./",
+    "octokit": "https://cdn.skypack.dev/octokit?dts",
+    "@octokit/types": "https://esm.sh/@octokit/types@6.34.0",
+    "@octokit/auth-oauth-user": "https://esm.sh/@octokit/auth-oauth-user@1.3.0",
+    "@octokit/oauth-authorization-url": "https://esm.sh/@octokit/oauth-authorization-url@4.3.3",
+    "std/": "https://deno.land/std@0.143.0/"
+  }
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,129 @@
+import { endpoints } from "./endpoints.ts";
+import { fetchOAuthApp } from "./fetch-oauth-app.ts";
+import type {
+  Auth,
+  AuthenticatorMethods,
+  AuthenticatorState,
+  ClientTypes,
+  OAuthAuthorizationUrlOptions,
+} from "./types.ts";
+import { oauthAuthorizationUrl } from "@octokit/oauth-authorization-url";
+
+export const auth = <
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+>(
+  state: AuthenticatorState<ClientType, ExpirationEnabled>,
+) => {
+  type Command = AuthenticatorMethods<ClientType, ExpirationEnabled>;
+  const authStore = state.authStore || undefined;
+  const stateStore = state.stateStore || undefined;
+
+  const fetchAuth = async (
+    type: keyof typeof endpoints,
+    token: string | null,
+    body: Record<string, unknown> | null,
+  ) => {
+    let auth = (await fetchOAuthApp(state, type, token, body))
+      ?.authentication || null;
+    if (auth) auth = { ...(state.auth || {}), ...auth };
+    return await setAuth(auth);
+  };
+
+  const setAuth = async (
+    auth: Auth<ClientType, ExpirationEnabled> | null = null,
+  ) => {
+    await authStore?.set(auth);
+    return (state.auth = auth);
+  };
+
+  return async function auth(
+    command: Command = { type: "getToken" },
+  ): Promise<Auth<ClientType, ExpirationEnabled> | null> {
+    const { type, ...commandOptions } = command;
+
+    const url = new URL(state.location.href);
+    const code = url.searchParams.get("code");
+    const newState = url.searchParams.get("state");
+
+    switch (type) {
+      case "signIn": {
+        await setAuth(); // clear local auth before redirecting
+        const newState = Math.random().toString(36).substring(2);
+        stateStore?.set(newState);
+        const redirectUrl = oauthAuthorizationUrl<ClientType>({
+          clientType: state.clientType,
+          clientId: state.clientId,
+          redirectUrl: state.location.href,
+          state: newState,
+          ...commandOptions,
+        } as OAuthAuthorizationUrlOptions<ClientType>).url;
+        state.location.href = redirectUrl;
+        return null;
+      }
+
+      case "getToken": {
+        if (!code || !newState) {
+          state.auth ||= (await authStore?.get()) || null;
+          if (!state.auth) return null;
+          if (
+            // @ts-ignore better than a one-time assertion function
+            !state.auth.expiresAt || new Date(state.auth.expiresAt) > new Date()
+          ) {
+            return state.auth;
+          }
+          return await auth({ type: "renewToken" } as Command);
+        }
+      }
+
+      /* falls through */
+
+      case "createToken": {
+        if (!code || !newState) {
+          throw Error('Both "code" & "state" parameters are required.');
+        }
+        url.searchParams.delete("code");
+        url.searchParams.delete("state");
+        const redirectUrl = url.href;
+        // @ts-ignore mock `window.history` in tests
+        window.history.replaceState({}, "", redirectUrl);
+        const oldState = (await stateStore?.get());
+        await stateStore?.set(null);
+        if (stateStore && (newState != oldState)) {
+          throw Error("State mismatch.");
+        }
+        return await fetchAuth("createToken", null, {
+          state: newState, // TODO: this is unnecessary, update oauth-app
+          code,
+          redirectUrl,
+        });
+      }
+
+      case "checkToken":
+      case "createScopedToken":
+      case "resetToken":
+      case "renewToken":
+      case "deleteToken":
+      case "deleteAuthorization": {
+        let body: Record<string, unknown> | null = null;
+        if (["POST", "PUT", "PATCH"].includes(endpoints[type]?.[0])) {
+          const { type: _, ..._payload } = command as Record<string, unknown>;
+          body = _payload;
+        }
+        if (type === "deleteToken" && command.offline) return await setAuth();
+        if (type === "renewToken") {
+          if (state.auth) {
+            const auth = state.auth as Auth<ClientType, true>;
+            const renewableUntil = new Date(auth.refreshTokenExpiresAt);
+            if (new Date() > renewableUntil) return await setAuth();
+            body!.refreshToken = auth.refreshToken;
+          }
+        } else state.auth = await auth();
+        if (!state.auth) throw Error("Unauthorized.");
+        const { token } = state.auth; // TODO: does `renewToken` need token?
+        if (type.startsWith("delete")) await setAuth();
+        return await fetchAuth(type, token, body);
+      }
+    }
+  };
+};

--- a/src/create-store.ts
+++ b/src/create-store.ts
@@ -1,0 +1,18 @@
+import { NAME } from "./metadata.ts";
+import type { Store } from "./types.ts";
+
+export const createStore = <T>(key: string): Store<T> => {
+  const _key = NAME + ":" + key;
+  const _localStorage = localStorage;
+  return {
+    get: () => {
+      const text = _localStorage.getItem(_key);
+      return text ? JSON.parse(text) as T : null;
+    },
+    set: (value) => {
+      value
+        ? _localStorage.setItem(_key, JSON.stringify(value))
+        : _localStorage.removeItem(_key);
+    },
+  };
+};

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,0 +1,10 @@
+// TODO: better defined in `oauth-app.js`
+export const endpoints = {
+  createToken: ["POST", "/token"],
+  checkToken: ["GET", "/token"],
+  createScopedToken: ["POST", "/token/scoped"],
+  resetToken: ["PATCH", "/token"],
+  renewToken: ["PATCH", "/refresh-token"],
+  deleteToken: ["DELETE", "/token"],
+  deleteAuthorization: ["DELETE", "/grant"],
+} as const;

--- a/src/fetch-oauth-app.ts
+++ b/src/fetch-oauth-app.ts
@@ -1,0 +1,31 @@
+import { endpoints } from "./endpoints.ts";
+import { NAME, VERSION } from "./metadata.ts";
+import type { AuthenticatorState, ClientTypes } from "./types.ts";
+
+export const fetchOAuthApp = async <
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+>(
+  state: AuthenticatorState<ClientType, ExpirationEnabled>,
+  command: keyof typeof endpoints,
+  token: string | null,
+  body: Record<string, unknown> | null,
+) => {
+  const [method, path] = endpoints[command];
+  const headers: Record<string, string> = {
+    "user-agent": `${NAME}/${VERSION} ${navigator.userAgent}`,
+    ...(token ? { authorization: "token " + token } : {}),
+    ...(body ? { "content-type": "application/json; charset=utf-8" } : {}),
+    accept: "application/json",
+  };
+  const route = state.serviceOrigin + state.servicePathPrefix + path;
+  const { fetch } = state;
+  const response = await fetch(route, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!response.ok) throw new Error(await response.text());
+  if (response.status === 204) return null;
+  return await response.json();
+};

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,0 +1,47 @@
+import { requiresBasicAuth } from "./requires-basic-auth.ts";
+import type { Auth, ClientTypes } from "./types.ts";
+import type {
+  EndpointDefaults,
+  EndpointOptions,
+  OctokitResponse,
+  RequestInterface,
+  RequestParameters,
+  Route,
+} from "@octokit/types";
+
+export const hook = <
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+>(_auth: () => Promise<Auth<ClientType, ExpirationEnabled> | null>): <T>(
+  request: RequestInterface,
+  route: Route | EndpointOptions,
+  parameters: RequestParameters,
+) => Promise<AnyResponse<T>> => {
+  return async <T>(
+    request: RequestInterface,
+    route: Route | EndpointOptions,
+    parameters: RequestParameters = {},
+  ): Promise<AnyResponse<T>> => {
+    const endpoint = request.endpoint.merge(
+      route as string,
+      parameters,
+    ) as EndpointDefaults & { url: string };
+
+    // unable to perform basic authentication since client secret is missing
+    if (requiresBasicAuth(endpoint.url)) {
+      throw Error("Basic authentication is unsupported.");
+    }
+
+    // do not intercept OAuth Web flow requests
+    const oauthWebFlowUrls = /\/login\/(oauth\/access_token|device\/code)$/;
+    if (!oauthWebFlowUrls.test(endpoint.url)) {
+      const auth = await _auth();
+      const token = auth?.token;
+      if (token) endpoint.headers.authorization = "token " + token;
+    }
+
+    return request(endpoint);
+  };
+};
+
+type AnyResponse<T> = OctokitResponse<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,42 @@
+/// <reference lib="dom" />
+import { auth } from "./auth.ts";
+import { createStore } from "./create-store.ts";
+import { hook } from "./hook.ts";
+import type {
+  AuthStrategy,
+  AuthStrategyOptions,
+  ClientTypes,
+  OptionalAuthStrategyOptions,
+} from "./types.ts";
+
+export const createOAuthUserClientAuth = <
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+>(
+  options: AuthStrategyOptions<ClientType, ExpirationEnabled>,
+): AuthStrategy<
+  ClientType,
+  ExpirationEnabled
+> => {
+  if (options.clientType === "oauth-app" && options.expirationEnabled) {
+    throw Error("OAuth App does not support token expiration.");
+  }
+
+  const defaultOptions = {
+    authStore: createStore(`AUTH:${options.clientId}`),
+    stateStore: createStore(`STATE:${options.clientId}`),
+    auth: null,
+    ...(options.clientType === "oauth-app"
+      ? { defaultScopes: [] as string[] }
+      : {}),
+    serviceOrigin: location.origin,
+    servicePathPrefix: "/api/github/oauth",
+    location,
+    fetch,
+  } as OptionalAuthStrategyOptions<ClientType, ExpirationEnabled>;
+
+  const state = { ...defaultOptions, ...options };
+  if (options.auth && state.authStore) state.authStore.set(options.auth);
+  const _auth = auth(state);
+  return Object.assign(_auth, { hook: hook(_auth) });
+};

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,2 @@
+export const NAME = "@octokit/auth-oauth-user-client.js";
+export const VERSION = "0.1.0";

--- a/src/requires-basic-auth.ts
+++ b/src/requires-basic-auth.ts
@@ -1,0 +1,21 @@
+/**
+ * The following endpoints require an OAuth App to authenticate using its client_id and client_secret.
+ *
+ * - [`POST /applications/{client_id}/token`](https://docs.github.com/en/rest/reference/apps#check-a-token) - Check a token
+ * - [`PATCH /applications/{client_id}/token`](https://docs.github.com/en/rest/reference/apps#reset-a-token) - Reset a token
+ * - [`POST /applications/{client_id}/token/scoped`](https://docs.github.com/en/rest/reference/apps#create-a-scoped-access-token) - Create a scoped access token
+ * - [`DELETE /applications/{client_id}/token`](https://docs.github.com/en/rest/reference/apps#delete-an-app-token) - Delete an app token
+ * - [`DELETE /applications/{client_id}/grant`](https://docs.github.com/en/rest/reference/apps#delete-an-app-authorization) - Delete an app authorization
+ *
+ * deprecated:
+ *
+ * - [`GET /applications/{client_id}/tokens/{access_token}`](https://docs.github.com/en/rest/reference/apps#check-an-authorization) - Check an authorization
+ * - [`POST /applications/{client_id}/tokens/{access_token}`](https://docs.github.com/en/rest/reference/apps#reset-an-authorization) - Reset an authorization
+ * - [`DELETE /applications/{client_id}/tokens/{access_token}`](https://docs.github.com/en/rest/reference/apps#revoke-an-authorization-for-an-application) - Revoke an authorization for an application
+ * - [`DELETE /applications/{client_id}/grants/{access_token}`](https://docs.github.com/en/rest/reference/apps#revoke-a-grant-for-an-application) - Revoke a grant for an application
+ */
+const ROUTES_REQUIRING_BASIC_AUTH = /\/applications\/[^/]+\/(token|grant)s?/;
+
+export function requiresBasicAuth(url: string | undefined) {
+  return url && ROUTES_REQUIRING_BASIC_AUTH.test(url);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,190 @@
+import type {
+  GitHubAppAuthentication,
+  OAuthAppAuthentication,
+} from "@octokit/auth-oauth-user";
+
+import type {
+  EndpointOptions,
+  OctokitResponse,
+  RequestInterface,
+  RequestParameters,
+  Route,
+} from "@octokit/types";
+
+// An `AuthStrategy` is a function that takes a single parameter of type
+// `AuthStrategyOptions`  and returns an `Authenticator`. An `Authenticator` is
+// also a function (with state of type `AuthenticatorState`) that takes an
+// `AuthenticatorMethods` and returns an `Auth` with `token`.
+
+export type ClientTypes = OAuthApp | GitHubApp;
+export type OAuthApp = "oauth-app";
+export type GitHubApp = "github-app";
+
+/**
+ * A generic version of `AuthInterface` defined in [@octokit/types.ts][1]
+ * [1]: https://github.com/octokit/types.ts/blob/master/src/AuthInterface.ts
+ *
+ * > Interface to implement complex authentication strategies for Octokit.
+ *   An object Implementing the AuthInterface can directly be passed as the
+ *   `auth` option in the Octokit constructor.
+ *
+ * > For the official implementations of the most common authentication
+ *   strategies, see https://github.com/octokit/auth.js
+ */
+export interface AuthStrategy<
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+> {
+  (
+    method?: AuthenticatorMethods<ClientType, ExpirationEnabled>,
+  ): Promise<Auth<ClientType, ExpirationEnabled> | null>;
+
+  hook<T = unknown>(
+    request: RequestInterface,
+    route: Route | EndpointOptions,
+    parameters?: RequestParameters,
+  ): Promise<OctokitResponse<T>>;
+}
+
+/**
+ * Supported methods of a created client authentication strategy:
+ *
+ * 1. Get token
+ * 2. [Sign in](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity)
+ * 3. [Create an app token](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github)
+ * 4. [Check a token](https://docs.github.com/en/rest/reference/apps#check-a-token)
+ * 5. [Create a scoped access token](https://docs.github.com/en/rest/reference/apps#create-a-scoped-access-token)
+ * 6. [Reset a token](https://docs.github.com/en/rest/reference/apps#reset-a-token)
+ * 7. [Renewing a user token with a refresh token](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens#renewing-a-user-token-with-a-refresh-token)
+ * 8. [Delete an app token](https://docs.github.com/en/rest/reference/apps#delete-an-app-token) (sign out)
+ * 9. [Delete an app
+ *    authorization](https://docs.github.com/en/rest/reference/apps#delete-an-app-authorization)
+ */
+export type AuthenticatorMethods<
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+> =
+  | { type: "getToken" }
+  | (
+    & {
+      type: "signIn";
+      login?: string;
+      allowSignup?: boolean;
+    }
+    & (ClientType extends OAuthApp ? { scopes?: string[] }
+      : Record<never, never>)
+  )
+  | { type: "createToken" }
+  | { type: "checkToken" }
+  | (ClientType extends OAuthApp ? { type: "createScopedToken" } : never)
+  | { type: "resetToken" }
+  | (ExpirationEnabled extends true ? { type: "renewToken" } : never)
+  | { type: "deleteToken"; offline?: boolean }
+  | { type: "deleteAuthorization" };
+
+/**
+ * Authentication object returned from [`@octokit/oauth-app.js`][1].
+ *
+ * [1]: https://github.com/octokit/oauth-app.js
+ */
+export type Auth<
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+> =
+  & (ExpirationEnabled extends true ? {
+    expiresAt: string;
+    refreshToken: string;
+    refreshTokenExpiresAt: string;
+  }
+    : Record<never, never>)
+  & Omit<
+    (ClientType extends OAuthApp ? OAuthAppAuthentication
+      : GitHubAppAuthentication),
+    "clientSecret"
+  >;
+
+/**
+ * State of an authenticator. Missing options have default values.
+ */
+export type AuthenticatorState<
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+> = Required<AuthStrategyOptions<ClientType, ExpirationEnabled>>;
+
+/** Options to create an authenticator. */
+export type AuthStrategyOptions<
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+> =
+  & MandatoryAuthStrategyOptions<ClientType, ExpirationEnabled>
+  & Partial<OptionalAuthStrategyOptions<ClientType, ExpirationEnabled>>;
+
+/** Mandatory options to create an authenticator. */
+type MandatoryAuthStrategyOptions<
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+> = {
+  clientId: string;
+  clientType: ClientType;
+  expirationEnabled: ExpirationEnabled;
+};
+
+/** Optional options to create an authenticator. */
+export type OptionalAuthStrategyOptions<
+  ClientType extends ClientTypes,
+  ExpirationEnabled extends boolean,
+> = {
+  // generic properties
+  auth: Auth<ClientType, ExpirationEnabled> | null;
+  authStore: Store<Auth<ClientType, ExpirationEnabled>> | false;
+  defaultScopes: ClientType extends OAuthApp ? string[] : never;
+
+  // non-generic properties
+  location: Location;
+  fetch: typeof fetch;
+  serviceOrigin: string;
+  servicePathPrefix: string;
+  stateStore: Store<string> | false;
+};
+
+/**
+ * Generic store to persist authentication object or oauth `state` for [web
+ * application flow][1].
+ *
+ * [1]: https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow
+ */
+export type Store<T> = {
+  get: () => T | null | Promise<T | null>;
+  set: (value: T | null) => void | Promise<void>;
+};
+
+// TODO: making @octokit/oauth-authorization-url generic
+export type OAuthAuthorizationUrlOptions<ClientType extends ClientTypes> =
+  & {
+    clientType: ClientType;
+    clientId: string;
+    allowSignup?: boolean;
+    login?: string;
+    redirectUrl?: string;
+    state?: string;
+    baseUrl?: string;
+  }
+  & (ClientType extends OAuthApp ? { scopes?: string | string[] }
+    : Record<never, never>);
+
+type OAuthAuthorizationUrlResult<ClientType extends ClientTypes> = {
+  allowSignup: boolean;
+  clientId: string;
+  clientType: ClientType;
+  login?: string;
+  redirectUrl?: string;
+  state: string;
+  url: string;
+} & (ClientType extends OAuthApp ? { scopes: string[] } : Record<never, never>);
+
+export { oauthAuthorizationUrl } from "@octokit/oauth-authorization-url";
+declare module "@octokit/oauth-authorization-url" {
+  function oauthAuthorizationUrl<ClientType extends ClientTypes>(
+    options: OAuthAuthorizationUrlOptions<ClientType>,
+  ): OAuthAuthorizationUrlResult<ClientType>;
+}

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,1303 @@
+import { createOAuthUserClientAuth } from "../src/index.ts";
+import { NAME, VERSION } from "../src/metadata.ts";
+import { Auth, GitHubApp } from "../src/types.ts";
+import { createServerAuthenticationResponse } from "./utils.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStrictEquals,
+} from "std/testing/asserts.ts";
+import {
+  assertSpyCall,
+  assertSpyCalls,
+  returnsNext,
+  spy,
+  stub,
+} from "std/testing/mock.ts";
+
+const userAgent = `${NAME}/${VERSION} ${navigator.userAgent}`;
+
+const oauthApp = "oauth-app";
+const githubApp = "github-app";
+const tokenType = "oauth";
+const type = "token";
+const clientId = "client_id";
+const refreshToken1 = "refresh_token_1";
+const refreshToken2 = "refresh_token_2";
+const token1 = "token_123";
+const token2 = "token_456";
+const token3 = "token_789";
+const past = "2000-01-01T00:00:00.000Z";
+const future1 = "9999-01-01T00:00:00.000Z";
+const future2 = "9999-01-02T00:00:00.000Z";
+const stateKey = `${NAME}:STATE:${clientId}`;
+const authKey = `${NAME}:AUTH:${clientId}`;
+
+const gitHubAppExpiringValidAuth: Auth<GitHubApp, true> = {
+  tokenType,
+  type,
+  clientId,
+  clientType: githubApp,
+  token: token1,
+  expiresAt: future1,
+  refreshToken: refreshToken1,
+  refreshTokenExpiresAt: future1,
+} as const;
+
+const gitHubAppExpiredRenewableAuth: Auth<GitHubApp, true> = {
+  tokenType,
+  type,
+  clientId,
+  clientType: githubApp,
+  token: token1,
+  expiresAt: past,
+  refreshToken: refreshToken1,
+  refreshTokenExpiresAt: future1,
+} as const;
+
+const gitHubAppExpiredUnrenewableAuth: Auth<GitHubApp, true> = {
+  tokenType,
+  type,
+  clientId,
+  clientType: githubApp,
+  token: token1,
+  expiresAt: past,
+  refreshToken: refreshToken1,
+  refreshTokenExpiresAt: past,
+} as const;
+
+const checkedAuth = {
+  tokenType,
+  type,
+  clientId,
+  clientType: githubApp,
+  token: token1,
+} as const;
+
+// authentication returned from reset token endpoint
+const resettedAuth = {
+  tokenType,
+  type,
+  clientId,
+  clientType: githubApp,
+  token: token2,
+} as const;
+
+// authentication returned from renew token endpoint
+const renewedAuth = {
+  tokenType,
+  type,
+  clientId,
+  clientType: githubApp,
+  token: token3,
+  expiresAt: future2,
+  refreshToken: refreshToken2,
+  refreshTokenExpiresAt: future2,
+} as const;
+
+localStorage.clear();
+
+// location needs be mocked for this test
+Deno.test("sign in", async (t) => {
+  await t.step("when signed out", async () => {
+    const href = "https://acme.com/search?q=octokit";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      location,
+    });
+
+    assertEquals(localStorage.length, 0);
+    assertEquals(await authenticator(), null);
+
+    const auth = await authenticator({ type: "signIn" });
+    assertEquals(auth, null);
+
+    assertEquals(localStorage.length, 1);
+    const state = JSON.parse(localStorage.getItem(stateKey)!);
+
+    const url = new URL(location.href);
+    assertEquals(url.origin, "https://github.com");
+    assertEquals(url.pathname, "/login/oauth/authorize");
+    assertEquals(url.searchParams.get("allow_signup"), "true");
+    assertEquals(url.searchParams.get("client_id"), clientId);
+    assertEquals(url.searchParams.get("redirect_uri"), href);
+    assertEquals(url.searchParams.get("state"), state);
+
+    localStorage.clear();
+  });
+
+  await t.step("when already signed in", async () => {
+    const href = "https://acme.com/search?q=octokit";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+      location,
+    });
+
+    assertEquals(localStorage.length, 1);
+    assertEquals(localStorage.key(0), authKey);
+    assertEquals(await authenticator(), gitHubAppExpiringValidAuth);
+
+    const auth = await authenticator({ type: "signIn" });
+    assertEquals(auth, null);
+
+    assertEquals(localStorage.length, 1);
+    const state = JSON.parse(localStorage.getItem(stateKey)!);
+
+    const url = new URL(location.href);
+    assertEquals(url.origin, "https://github.com");
+    assertEquals(url.pathname, "/login/oauth/authorize");
+    assertEquals(url.searchParams.get("allow_signup"), "true");
+    assertEquals(url.searchParams.get("client_id"), clientId);
+    assertEquals(url.searchParams.get("redirect_uri"), href);
+    assertEquals(url.searchParams.get("state"), state);
+
+    localStorage.clear();
+  });
+
+  await t.step("accepts login, allowSignUp, and scopes", async () => {
+    const href = "https://acme.com/search?q=octokit";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: oauthApp,
+      expirationEnabled: false,
+      location,
+    });
+
+    assertEquals(localStorage.length, 0);
+    assertStrictEquals(await authenticator(), null);
+
+    const login = "john";
+    const allowSignup = false;
+    const scopes = ["user", "repo"];
+    const command = { type: "signIn", login, allowSignup, scopes } as const;
+    const auth = await authenticator(command);
+    assertStrictEquals(auth, null);
+
+    assertEquals(localStorage.length, 1);
+    const state = JSON.parse(localStorage.getItem(stateKey)!);
+
+    const url = new URL(location.href);
+    assertEquals(url.origin, "https://github.com");
+    assertEquals(url.pathname, "/login/oauth/authorize");
+    assertEquals(url.searchParams.get("allow_signup"), `${allowSignup}`);
+    assertEquals(url.searchParams.get("client_id"), clientId);
+    assertEquals(url.searchParams.get("login"), login);
+    assertEquals(url.searchParams.get("redirect_uri"), href);
+    assertEquals(url.searchParams.get("scope"), scopes.join(","));
+    assertEquals(url.searchParams.get("state"), state);
+
+    assertEquals(localStorage.length, 1);
+    assertEquals(localStorage.key(0), stateKey);
+
+    localStorage.clear();
+  });
+});
+
+Deno.test("get token", async (t) => {
+  await t.step("when signed out", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+    });
+
+    assertEquals(await authenticator(), null);
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+
+  await t.step("when signed out, no auth store", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      authStore: false,
+    });
+
+    assertEquals(await authenticator(), null);
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+
+  await t.step("initial authentication from code", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertEquals(await authenticator(), gitHubAppExpiringValidAuth);
+    assertEquals(localStorage.length, 1);
+    assertEquals(localStorage.key(0), authKey);
+    localStorage.clear();
+  });
+
+  await t.step("initial authentication from store", async () => {
+    localStorage.setItem(authKey, JSON.stringify(gitHubAppExpiringValidAuth));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+    });
+
+    assertEquals(await authenticator(), gitHubAppExpiringValidAuth);
+    assertEquals(localStorage.length, 1);
+    assertEquals(localStorage.key(0), authKey);
+    localStorage.clear();
+  });
+
+  await t.step("expiring but still valid", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertStrictEquals(await authenticator(), gitHubAppExpiringValidAuth);
+    localStorage.clear();
+  });
+
+  await t.step("expired but renewable", async () => {
+    const response = createServerAuthenticationResponse(renewedAuth);
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredRenewableAuth,
+    });
+
+    assertEquals(await authenticator(), renewedAuth);
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: ["https://acme.com/api/github/oauth/refresh-token", {
+        method: "PATCH",
+        headers: {
+          "user-agent": userAgent,
+          authorization: `token ${gitHubAppExpiredRenewableAuth.token}`,
+          "content-type": "application/json; charset=utf-8",
+          accept: "application/json",
+        },
+        body: JSON.stringify({
+          refreshToken: gitHubAppExpiredRenewableAuth.refreshToken,
+        }),
+      }],
+    });
+
+    assertEquals(localStorage.length, 1);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired and unrenewable", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredUnrenewableAuth,
+    });
+
+    assertStrictEquals(await authenticator(), null);
+    assertStrictEquals(localStorage.length, 0);
+
+    localStorage.clear();
+  });
+});
+
+Deno.test("create token", async (t) => {
+  await t.step("using get token", async () => {
+    const response = createServerAuthenticationResponse(
+      gitHubAppExpiringValidAuth,
+    );
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const replaceState = () => {};
+    const replaceStateSpy = spy(replaceState);
+    Object.assign(window, { history: { replaceState: replaceStateSpy } });
+    localStorage.setItem(stateKey, JSON.stringify("state"));
+    const href = "https://acme.com/search?q=octokit&code=code&state=state";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      location,
+    });
+
+    assertEquals(
+      await authenticator({ type: "getToken" }),
+      gitHubAppExpiringValidAuth,
+    );
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "POST",
+          headers: {
+            "user-agent": userAgent,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            "state": "state",
+            "code": "code",
+            "redirectUrl": "https://acme.com/search?q=octokit",
+          }),
+        },
+      ],
+    });
+
+    assertSpyCalls(replaceStateSpy, 1);
+    assertSpyCall(replaceStateSpy, 0, {
+      args: [{}, "", "https://acme.com/search?q=octokit"],
+    });
+
+    assertEquals(localStorage.length, 1);
+    assertEquals(
+      JSON.parse(localStorage.getItem(authKey) as string),
+      gitHubAppExpiringValidAuth,
+    );
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("when signed out", async () => {
+    const response = createServerAuthenticationResponse(
+      gitHubAppExpiringValidAuth,
+    );
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const replaceState = () => {};
+    const replaceStateSpy = spy(replaceState);
+    Object.assign(window, { history: { replaceState: replaceStateSpy } });
+    localStorage.setItem(stateKey, JSON.stringify("state"));
+    const href = "https://acme.com/search?q=octokit&code=code&state=state";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      location,
+    });
+
+    assertEquals(
+      await authenticator({ type: "createToken" }),
+      gitHubAppExpiringValidAuth,
+    );
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "POST",
+          headers: {
+            "user-agent": userAgent,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            "state": "state",
+            "code": "code",
+            "redirectUrl": "https://acme.com/search?q=octokit",
+          }),
+        },
+      ],
+    });
+
+    assertSpyCalls(replaceStateSpy, 1);
+    assertSpyCall(replaceStateSpy, 0, {
+      args: [{}, "", "https://acme.com/search?q=octokit"],
+    });
+
+    assertEquals(localStorage.length, 1);
+    assertEquals(
+      JSON.parse(localStorage.getItem(authKey) as string),
+      gitHubAppExpiringValidAuth,
+    );
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("state mismatch", async () => {
+    localStorage.setItem(stateKey, JSON.stringify("foo"));
+    const href = "https://acme.com/search?q=octokit&code=code&state=bar";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      location,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "createToken" }),
+      Error,
+      "State mismatch.",
+    );
+
+    localStorage.clear();
+  });
+
+  await t.step("when already signed in", async () => {
+    const response = createServerAuthenticationResponse(
+      gitHubAppExpiringValidAuth,
+    );
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const replaceState = () => {};
+    const replaceStateSpy = spy(replaceState);
+    Object.assign(window, { history: { replaceState: replaceStateSpy } });
+    localStorage.setItem(stateKey, JSON.stringify("state"));
+    const href = "https://acme.com/search?q=octokit&code=code&state=state";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      location,
+      auth: {} as unknown as Auth<GitHubApp, true>,
+    });
+
+    assertEquals(
+      await authenticator({ type: "createToken" }),
+      gitHubAppExpiringValidAuth,
+    );
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "POST",
+          headers: {
+            "user-agent": userAgent,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            "state": "state",
+            "code": "code",
+            "redirectUrl": "https://acme.com/search?q=octokit",
+          }),
+        },
+      ],
+    });
+
+    assertSpyCalls(replaceStateSpy, 1);
+    assertSpyCall(replaceStateSpy, 0, {
+      args: [{}, "", "https://acme.com/search?q=octokit"],
+    });
+
+    assertEquals(localStorage.length, 1);
+    assertEquals(
+      JSON.parse(localStorage.getItem(authKey) as string),
+      gitHubAppExpiringValidAuth,
+    );
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("no state store", async () => {
+    const response = createServerAuthenticationResponse(
+      gitHubAppExpiringValidAuth,
+    );
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const replaceState = () => {};
+    const replaceStateSpy = spy(replaceState);
+    Object.assign(window, { history: { replaceState: replaceStateSpy } });
+    const href = "https://acme.com/search?q=octokit&code=code&state=state";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      stateStore: false,
+      location,
+    });
+
+    assertEquals(
+      await authenticator({ type: "createToken" }),
+      gitHubAppExpiringValidAuth,
+    );
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "POST",
+          headers: {
+            "user-agent": userAgent,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            "state": "state",
+            "code": "code",
+            "redirectUrl": "https://acme.com/search?q=octokit",
+          }),
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 1);
+    assertEquals(
+      JSON.parse(localStorage.getItem(authKey) as string),
+      gitHubAppExpiringValidAuth,
+    );
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("missing code", async () => {
+    const href = "https://acme.com/search?q=octokit&state=state";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      location,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "createToken" }),
+      Error,
+      'Both "code" & "state" parameters are required.',
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+
+  await t.step("missing state", async () => {
+    const href = "https://acme.com/search?q=octokit&code=code";
+    const location = { href } as Location;
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      location,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "createToken" }),
+      Error,
+      'Both "code" & "state" parameters are required.',
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+});
+
+Deno.test("check token", async (t) => {
+  await t.step("when signed out", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "checkToken" }),
+      Error,
+      "Unauthorized.",
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+
+  await t.step("expiring but still valid", async () => {
+    const response = createServerAuthenticationResponse(checkedAuth);
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertEquals(await authenticator({ type: "checkToken" })!, {
+      ...gitHubAppExpiringValidAuth,
+      ...checkedAuth,
+    });
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "GET",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiringValidAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired but renewable", async () => {
+    const response1 = createServerAuthenticationResponse(renewedAuth);
+    const response2 = createServerAuthenticationResponse(checkedAuth);
+    const fetchStub = stub(
+      window,
+      "fetch",
+      returnsNext([response1, response2]),
+    );
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredRenewableAuth,
+    });
+
+    assertEquals(await authenticator({ type: "checkToken" }), {
+      ...renewedAuth,
+      ...checkedAuth,
+    });
+
+    assertSpyCalls(fetchStub, 2);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/refresh-token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiredRenewableAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            refreshToken: gitHubAppExpiredRenewableAuth.refreshToken,
+          }),
+        },
+      ],
+    });
+    assertSpyCall(fetchStub, 1, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "GET",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${renewedAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 1);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired and unrenewable", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredUnrenewableAuth,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "checkToken" }),
+      Error,
+      "Unauthorized.",
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+});
+
+Deno.test("reset token", async (t) => {
+  await t.step("when signed out", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "resetToken" }),
+      Error,
+      "Unauthorized.",
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+
+  await t.step("expiring but still valid", async () => {
+    const response = createServerAuthenticationResponse(resettedAuth);
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertEquals(await authenticator({ type: "resetToken" }), {
+      ...gitHubAppExpiringValidAuth,
+      ...resettedAuth,
+    });
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiringValidAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: "{}",
+        },
+      ],
+    });
+    assertEquals(localStorage.length, 1);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired but renewable", async () => {
+    const response1 = createServerAuthenticationResponse(renewedAuth);
+    const response2 = createServerAuthenticationResponse(resettedAuth);
+    const fetchStub = stub(
+      window,
+      "fetch",
+      returnsNext([response1, response2]),
+    );
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredRenewableAuth,
+    });
+
+    assertEquals(await authenticator({ type: "resetToken" }), {
+      ...renewedAuth,
+      ...resettedAuth,
+    });
+
+    assertSpyCalls(fetchStub, 2);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/refresh-token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiredRenewableAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            refreshToken: gitHubAppExpiredRenewableAuth.refreshToken,
+          }),
+        },
+      ],
+    });
+    assertSpyCall(fetchStub, 1, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${renewedAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: "{}",
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 1);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired and unrenewable", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredUnrenewableAuth,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "resetToken" }),
+      Error,
+      "Unauthorized.",
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+});
+
+Deno.test("renew token", async (t) => {
+  await t.step("when signed out", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "renewToken" }),
+      Error,
+      "Unauthorized.",
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+
+  await t.step("expiring but still valid", async () => {
+    const response = createServerAuthenticationResponse(renewedAuth);
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertEquals(await authenticator({ type: "renewToken" }), renewedAuth);
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/refresh-token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiredRenewableAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            refreshToken: gitHubAppExpiringValidAuth.refreshToken,
+          }),
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 1);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired but renewable", async () => {
+    const response = createServerAuthenticationResponse(renewedAuth);
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredRenewableAuth,
+    });
+
+    assertEquals(await authenticator({ type: "renewToken" }), renewedAuth);
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/refresh-token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiredRenewableAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            refreshToken: gitHubAppExpiredRenewableAuth.refreshToken,
+          }),
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 1);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired and unrenewable", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredUnrenewableAuth,
+    });
+
+    assertStrictEquals(await authenticator({ type: "renewToken" }), null);
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+});
+
+Deno.test("delete token", async (t) => {
+  await t.step("when signed out", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+    });
+    await assertRejects(
+      () => authenticator({ type: "deleteToken" }),
+      Error,
+      "Unauthorized.",
+    );
+  });
+
+  await t.step("expiring but still valid", async () => {
+    const response = createServerAuthenticationResponse(null);
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertEquals(await authenticator({ type: "deleteToken" }), null);
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "DELETE",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiringValidAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 0);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired but renewable", async () => {
+    const response1 = createServerAuthenticationResponse(renewedAuth);
+    const response2 = createServerAuthenticationResponse(null);
+    const fetchStub = stub(
+      window,
+      "fetch",
+      returnsNext([response1, response2]),
+    );
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredRenewableAuth,
+    });
+
+    assertEquals(await authenticator({ type: "deleteToken" }), null);
+
+    assertSpyCalls(fetchStub, 2);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/refresh-token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiredRenewableAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({ refreshToken: "refresh_token_1" }),
+        },
+      ],
+    });
+    assertSpyCall(fetchStub, 1, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "DELETE",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${renewedAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 0);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired and unrenewable", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredUnrenewableAuth,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "deleteToken" }),
+      Error,
+      "Unauthorized.",
+    );
+  });
+
+  await t.step("offline", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertEquals(
+      await authenticator({ type: "deleteToken", offline: true }),
+      null,
+    );
+
+    assertEquals(localStorage.length, 0);
+    localStorage.clear();
+  });
+
+  await t.step("on service error", async () => {
+    const error = "service error";
+    const response = Promise.resolve(new Response(error, { status: 500 }));
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "deleteToken" }),
+      Error,
+      "service error",
+    );
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/token",
+        {
+          method: "DELETE",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiringValidAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 0);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+});
+
+Deno.test("delete authorization", async (t) => {
+  await t.step("when signed out", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+    });
+    await assertRejects(
+      () => authenticator({ type: "deleteAuthorization" }),
+      Error,
+      "Unauthorized.",
+    );
+  });
+
+  await t.step("expiring but still valid", async () => {
+    const response = createServerAuthenticationResponse(null);
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    assertEquals(await authenticator({ type: "deleteAuthorization" }), null);
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/grant",
+        {
+          method: "DELETE",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiringValidAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 0);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired but renewable", async () => {
+    const response1 = createServerAuthenticationResponse(renewedAuth);
+    const response2 = createServerAuthenticationResponse(null);
+    const fetchStub = stub(
+      window,
+      "fetch",
+      returnsNext([response1, response2]),
+    );
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredRenewableAuth,
+    });
+
+    assertEquals(await authenticator({ type: "deleteAuthorization" }), null);
+
+    assertSpyCalls(fetchStub, 2);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/refresh-token",
+        {
+          method: "PATCH",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiredRenewableAuth.token}`,
+            "content-type": "application/json; charset=utf-8",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            refreshToken: gitHubAppExpiredRenewableAuth.refreshToken,
+          }),
+        },
+      ],
+    });
+    assertSpyCall(fetchStub, 1, {
+      args: [
+        "https://acme.com/api/github/oauth/grant",
+        {
+          method: "DELETE",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${renewedAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 0);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+
+  await t.step("expired and unrenewable", async () => {
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiredUnrenewableAuth,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "deleteAuthorization" }),
+      Error,
+      "Unauthorized.",
+    );
+  });
+
+  await t.step("on service error", async () => {
+    const error = "service error";
+    const response = Promise.resolve(new Response(error, { status: 500 }));
+    const fetchStub = stub(window, "fetch", returnsNext([response]));
+    const authenticator = createOAuthUserClientAuth({
+      clientId,
+      clientType: githubApp,
+      expirationEnabled: true,
+      auth: gitHubAppExpiringValidAuth,
+    });
+
+    await assertRejects(
+      () => authenticator({ type: "deleteAuthorization" }),
+      Error,
+      error,
+    );
+
+    assertSpyCalls(fetchStub, 1);
+    assertSpyCall(fetchStub, 0, {
+      args: [
+        "https://acme.com/api/github/oauth/grant",
+        {
+          method: "DELETE",
+          headers: {
+            "user-agent": userAgent,
+            authorization: `token ${gitHubAppExpiringValidAuth.token}`,
+            accept: "application/json",
+          },
+        },
+      ],
+    });
+
+    assertEquals(localStorage.length, 0);
+
+    fetchStub.restore();
+    localStorage.clear();
+  });
+});

--- a/test/hook.test.ts
+++ b/test/hook.test.ts
@@ -1,0 +1,64 @@
+import { Octokit } from "octokit";
+import { createOAuthUserClientAuth } from "../src/index.ts";
+import { AuthStrategyOptions, GitHubApp } from "../src/types.ts";
+import { createServerResponse } from "./utils.ts";
+import { assert, assertRejects } from "std/testing/asserts.ts";
+import { returnsNext, stub } from "std/testing/mock.ts";
+
+const gitHubAppExpirationDisabledAuth = {
+  tokenType: "oauth",
+  type: "token",
+  clientId: "client_id",
+  clientType: "github-app",
+  token: "token_123",
+} as const;
+
+const githubApp = "github-app";
+const clientId = "client_id";
+
+Deno.test("can not perform basic authentication", async () => {
+  const clientAuthOptions: AuthStrategyOptions<GitHubApp, false> = {
+    clientId,
+    clientType: githubApp,
+    expirationEnabled: false,
+    auth: gitHubAppExpirationDisabledAuth,
+  };
+
+  const octokit = new Octokit({
+    authStrategy: createOAuthUserClientAuth,
+    auth: clientAuthOptions,
+  });
+
+  await assertRejects(
+    () => octokit.rest.apps.checkToken(),
+    Error,
+    "Basic authentication is unsupported.",
+  );
+
+  localStorage.clear();
+});
+
+Deno.test("do not intercept oauth web flow requests", async () => {
+  const userServer = { foo: "bar" };
+  const response = createServerResponse(userServer);
+  const fetchStub = stub(window, "fetch", returnsNext([response]));
+
+  const clientAuthOptions: AuthStrategyOptions<GitHubApp, false> = {
+    clientId,
+    clientType: githubApp,
+    expirationEnabled: false,
+    auth: gitHubAppExpirationDisabledAuth,
+  };
+
+  const octokit = new Octokit({
+    authStrategy: createOAuthUserClientAuth,
+    auth: clientAuthOptions,
+    request: { fetch: fetchStub },
+  });
+
+  await octokit.request("GET /login/oauth/access_token");
+  assert(!("authorization" in fetchStub.calls[0].args[1]?.headers!));
+
+  fetchStub.restore();
+  localStorage.clear();
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,71 @@
+import { Octokit } from "octokit";
+import { createOAuthUserClientAuth } from "../src/index.ts";
+import { AuthStrategyOptions, GitHubApp } from "../src/types.ts";
+import { createServerResponse } from "./utils.ts";
+import {
+  assertEquals,
+  assertObjectMatch,
+  assertThrows,
+} from "std/testing/asserts.ts";
+import { returnsNext, stub } from "std/testing/mock.ts";
+
+const gitHubAppExpirationDisabledAuth = {
+  tokenType: "oauth",
+  type: "token",
+  clientId: "client_id",
+  clientType: "github-app",
+  token: "token_123",
+} as const;
+
+const oauthApp = "oauth-app";
+const githubApp = "github-app";
+const clientId = "client_id";
+
+Deno.test("expiration disabled for oauth app currently", () => {
+  assertThrows(
+    () =>
+      createOAuthUserClientAuth({
+        clientId,
+        clientType: oauthApp,
+        expirationEnabled: true,
+      }),
+    Error,
+    "OAuth App does not support token expiration.",
+  );
+});
+
+Deno.test("get authenticated user", async () => {
+  const userServer = { foo: "bar" };
+  const response = createServerResponse(userServer);
+  const fetchStub = stub(window, "fetch", returnsNext([response]));
+
+  const clientAuthOptions: AuthStrategyOptions<GitHubApp, false> = {
+    clientId,
+    clientType: githubApp,
+    expirationEnabled: false,
+    auth: gitHubAppExpirationDisabledAuth,
+  };
+
+  const octokit = new Octokit({
+    authStrategy: createOAuthUserClientAuth,
+    auth: clientAuthOptions,
+    request: { fetch: fetchStub },
+  });
+
+  assertEquals(localStorage.length, 1);
+
+  const { data: userClient } = await octokit.rest.users.getAuthenticated();
+
+  assertEquals(userClient, userServer);
+  assertEquals(fetchStub.calls[0].args[0], "https://api.github.com/user");
+  assertObjectMatch(fetchStub.calls[0].args[1]!, {
+    method: "GET",
+    headers: {
+      accept: "application/vnd.github.v3+json",
+      authorization: `token ${gitHubAppExpirationDisabledAuth.token}`,
+    },
+  });
+
+  fetchStub.restore();
+  localStorage.clear();
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,12 @@
+export const createServerResponse = (body: unknown) =>
+  Promise.resolve(
+    new Response(body ? JSON.stringify(body) : null, {
+      status: body ? 200 : 204,
+      headers: body
+        ? { "content-type": "application/json; charset=utf-8" }
+        : {},
+    }),
+  );
+
+export const createServerAuthenticationResponse = (auth: unknown) =>
+  createServerResponse(auth ? { authentication: auth } : null);


### PR DESCRIPTION
This PR includes a rewrite of my previous draft implementation and an updated `README.md`.

Below snippet demonstrates the basic usage.

```js
import { Octokit } from "https://cdn.skypack.dev/@octokit/octokit";
import { createOAuthUserClientAuth } from "https://cdn.jsdelivr.net/gh/baoshan/auth-oauth-user-client.js@v0.1.0/dist/index.min.js";

const octokit = new Octokit({
  authStrategy: createOAuthUserClientAuth,
  auth: {
    clientId: "client_id", // get client id from https://github.com/settings/apps
    clientType: "github-app", // "github-app" | "oauth-app"
    expirationEnabled: true, // true | false
  },
});

const auth = await octokit.auth();
if (!auth) await octokit.auth({ type: "signIn" });
else console.log(await octokit.rest.users.getAuthenticated());
```

Although targeting browsers, this module is written, tested, and bundled using Deno for its simplicity. The (bundled and gzipped) size is slightly less than 2kB.

I’m grateful if @gr2m or @wolfy1339 could give it a review. Thanks again for your help.